### PR TITLE
modified scope for service account

### DIFF
--- a/hdfs2gcs-terraform/nifi-ca.tf
+++ b/hdfs2gcs-terraform/nifi-ca.tf
@@ -24,7 +24,7 @@ resource "google_compute_instance" "nifi-ca" {
     tags = ["nifi-ca"]
 
     service_account {
-        scopes = ["storage-ro"]
+        scopes = ["cloud-platform"]
     }
     
     boot_disk {

--- a/hdfs2gcs-terraform/nifi.tf
+++ b/hdfs2gcs-terraform/nifi.tf
@@ -54,7 +54,7 @@ resource "google_compute_instance" "nifi" {
   tags = ["nifi-host"]
 
   service_account {
-        scopes = ["storage-ro", "cloud-platform"]
+        scopes = ["cloud-platform"]
     }
   network_interface {  
     network            = google_compute_network.default.name
@@ -96,7 +96,7 @@ resource "google_compute_instance" "nifi" {
         su nifi -c 'unzip ${var.nifi-path}/nifi-toolkit-${var.nifi-version}-bin.zip -d ${var.nifi-path}'
         su nifi -c 'rm ${var.nifi-path}/nifi-toolkit-${var.nifi-version}-bin.zip'
         echo "testing the connection"
-        until ping -c1 nifi-ca >/dev/null 2>&1; do :; done
+        until nc -z nifi-ca 9443 >/dev/null 2>&1; do :; done
         
         su nifi -c 'cd ${var.nifi-path}/nifi-${var.nifi-version}/conf && ${var.nifi-path}/nifi-toolkit-${var.nifi-version}/bin/tls-toolkit.sh client  -c ${var.nifi-ca-hostname} -t ${var.ca-token} '
         until  ls ${var.nifi-path}/nifi-${var.nifi-version}/conf/config.json; do


### PR DESCRIPTION
- changing the service account scope
- waiting for nifi toolkit to start running on port 9443 on nifi CA