### PR TITLE
Fix java.net.SocketTimeoutException stemming from OS

### DIFF
--- a/hdfs2gcs-terraform/certs_auth/variables.tf
+++ b/hdfs2gcs-terraform/certs_auth/variables.tf
@@ -49,7 +49,7 @@ variable "disk-size" {
 variable "image" {
     description = "Source disk image."
     type        = string
-    default     = "ubuntu-1804-bionic-v20220419" 
+    default     = "centos-7-v20220406"
 }
 
 variable "instance-count-nifi" {


### PR DESCRIPTION
With current OS image `ubuntu-1804-bionic-v20220419` their seems to be network stack related issue leading to ` java.net.SocketTimeoutException` while nifi nodes initiate a intercommunication.

This seems to be remediated in `centos-7-v20220406`